### PR TITLE
Add `jobs` command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'telegram-bot-ruby', require: 'telegram/bot'
 gem 'dotenv'
 gem 'redis'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     descendants_tracker (0.0.4)
@@ -15,7 +16,11 @@ GEM
       multipart-post (>= 1.2, < 3)
     ice_nine (0.11.2)
     inflecto (0.0.2)
+    method_source (0.9.2)
     multipart-post (2.0.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     redis (4.1.0)
     telegram-bot-ruby (0.8.6.1)
       faraday
@@ -33,8 +38,12 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  pry
   redis
   telegram-bot-ruby
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
-   1.16.3
+   1.17.2

--- a/data/help.txt
+++ b/data/help.txt
@@ -6,5 +6,5 @@ I'll help you during the conference. Stay tuned :) 💎
 /vote - vote the talk
 /speakers - show information about speakers
 /places - afterparty places
-/job\_board - find a job here
+/jobs - find a job here
 /stop - please don't

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -1,0 +1,13 @@
+- id: 0
+  title: 'Super duper mega job'
+  company: 'Awesome company'
+  location: 'New York'
+  announce: 'short job description'
+  full_description: 'and some more detailed info'
+
+- id: 1
+  title: 'Mega awesome job'
+  company: 'SpaceX'
+  location: 'Saint P'
+  announce: 'short job description'
+  full_description: 'and some more detailed info'

--- a/dispatchers/job.rb
+++ b/dispatchers/job.rb
@@ -1,0 +1,36 @@
+module Dispatchers
+  class Job
+    JOBS = YAML.load_file('./data/jobs.yml')
+
+    attr_reader :bot
+
+    def initialize(bot)
+      @bot = bot
+    end
+
+    def more(callback)
+      data = JSON.parse(callback.data)
+      job = JOBS.detect { |j| j['id'] == data['job_id'] }
+      text = "*#{job['title']}*\nCompany: #{job['company']}\nLocation: #{job['location']}\n#{job['announce']}\n#{job['full_description']}"
+      bot.api.edit_message_text(
+        message_id: callback.message.message_id,
+        chat_id: callback.message.chat.id,
+        text: text,
+        parse_mode: :markdown
+      )
+    end
+
+    def jobs(ctx)
+      JOBS.each_with_index do |job, i|
+        text = "*#{job['title']}*\nCompany: #{job['company']}\nLocation: #{job['location']}\n#{job['announce']}"
+        more_button = Telegram::Bot::Types::InlineKeyboardMarkup.new(
+          inline_keyboard: [Telegram::Bot::Types::InlineKeyboardButton.new(
+                              text: 'Show more',
+                              callback_data: { command: 'more', job_id: i }.to_json
+                            )]
+        )
+        bot.api.send_message(chat_id: ctx.chat.id, text: text, parse_mode: :markdown, reply_markup: more_button)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here i implement `/jobs` command. If you want to add new job you need to add a record to `data/jobs.yaml`. Every job should have: `id`, `title`, `company`, `location`, `announce`(short description of the job) and `full_description`. When you go to `/jobs` you'll get all jobs in separated messages. Every job message has a button(More) to get full description.

p.s. code is not very good, but it works. Any suggestions and comments are welcome :)