### PR TITLE
Talk descriptions command: naive way

### DIFF
--- a/data/schedule.txt
+++ b/data/schedule.txt
@@ -6,34 +6,42 @@
 🕓 11:00
 🚩 *Ruby 3.0 Redux*
 🎤 Bozhidar Batsov
+❔ /talk\_1
 
 🕓 12:00
 🚩 *Business logic in Ruby without frameworks, libraries and persistence*
 🎤 Andrzej Krzywda
+❔ /talk\_2
 
 🕓 13:00
 🚩 *Thinking in graphs: Why GraphQL is not about mapping database to schema*
 🎤 Dmitry Tsepelev
+❔ /talk\_3
 
 🕓 14:00
 🚩 *Moving Beyond #call: Demystifying Functional Ruby*
 🎤 Piotr Solnica
+❔ /talk\_4
 
 🕓 15:00
 🚩 *Aspergers in IT*
 🎤 Michal Papis
+❔ /talk\_5
 
 🕓 16:00
 🚩 *Simple distributed systems in Ruby*
 🎤 Julian Pokrovsky
+❔ /talk\_6
 
 🕓 17:00
 🚩 *Case Study: how we made our core process 100 times faster (at least)*
 🎤 Benjamin Roth
+❔ /talk\_7
 
 🕓 18:00
 🚩 *Between Ruby and Javascript*
 🎤 Anna Selezniova
+❔ /talk\_8
 
 🕓 19:00
 🎉 *Afterparty*
@@ -46,34 +54,42 @@
 🕓 11:00
 🚩 *Anything new, Rails 6?*
 🎤 Nickolay Sverchkov
+❔ /talk\_9
 
 🕓 12:00
 🚩 *Embrace multi-model thinking!*
 🎤 Ivan Nemytchenko
+❔ /talk\_10
 
 🕓 13:00
 🚩 *How to test microservices and stay sane*
 🎤 Tatiana Shepeleva
+❔ /talk\_11
 
 🕓 14:00
 🚩 *Orchestration over Disorganization*
 🎤 Nick Sutterer
+❔ /talk\_12
 
 🕓 15:00
 🚩 *How to hijack, proxy and smuggle sockets with Rack/Ruby*
 🎤 David Halasz
+❔ /talk\_13
 
 🕓 16:00
 🚩 *Running Jobs at Scale*
 🎤 Kir Shatrov
+❔ /talk\_14
 
 🕓 17:00
 🚩 *Typical Rails app in Kubernetes - Tips & Tricks*
 🎤 Andrey Voronkov
+❔ /talk\_15
 
 🕓 18:00
 🚩 *The Future of library dependency management of Ruby*
 🎤 Hiroshi Shibata
+❔ /talk\_16
 
 🕓 19:00
 🎉 *Closing words*

--- a/data/talk_descriptions.json
+++ b/data/talk_descriptions.json
@@ -1,0 +1,66 @@
+{
+  "1": {
+    "photo": "AgADAgADl6oxG7ln-Eh8VfNqKq5wEj5bXw8ABHmqFiyZCC-bvzoDAAEC",
+    "caption": "🕓 Day 1, 11:00"
+  },
+  "2": {
+    "photo": "AgADAgADmKoxG7ln-EilbewZjtaTeau3UQ8ABD6nkS_oSC9qOKABAAEC",
+    "caption": "🕓 Day 1, 12:00"
+  },
+  "3": {
+    "photo": "AgADAgAEqjEbuWcISfBY_xu8-bmZXgH1DgAEzakMtsvmVWydTAYAAQI",
+    "caption": "🕓 Day 1, 13:00"
+  },
+  "4": {
+    "photo": "AgADAgADm6oxG7ltEUn-hNDFwgl7Vo5WUw8ABKvdrDgoMYdDRrIBAAEC",
+    "caption": "🕓 Day 1, 14:00"
+  },
+  "5": {
+    "photo": "AgADAgADq6oxG9YXIEm1gzQMP4qN9Sf09A4ABAVRIm8-c8zk61gGAAEC",
+    "caption": "🕓 Day 1, 15:00"
+  },
+  "6": {
+    "photo": "AgADAgADr6oxG9YXIEnHs5z-lsR_0ib89A4ABLlQrphTflNhyFwGAAEC",
+    "caption": "🕓 Day 1, 16:00"
+  },
+  "7": {
+    "photo": "AgADAgADGqoxGzLYMUnZVt6XuguNHzi0UQ8ABCFx4WfBZdDy-coBAAEC",
+    "caption": "🕓 Day 1, 17:00"
+  },
+  "8": {
+    "photo": "AgADAgADs6kxG8ESOUnp1bFVwfrxUB11Xw8ABGk5AXPp9Cd6X2IDAAEC",
+    "caption": "🕓 Day 1, 18:00"
+  },
+  "9": {
+    "photo": "AgADAgADIqoxG0NLWEkqvVIqy9Rggld5Xw8ABIFe-w76poTTPn0DAAEC",
+    "caption": "🕓 Day 2, 11:00"
+  },
+  "10": {
+    "photo": "AgADAgADQKoxGwi7aUmMKzEXk-wHN5KHUw8ABDYXw2Wn6M4Uv0cAAgI",
+    "caption": "🕓 Day 2, 12:00"
+  },
+  "11": {
+    "photo": "AgADAgADIKoxGz-McElgfQ-iRFy-VtlJUw8ABAY4Dsxf_ZFjUvwBAAEC",
+    "caption": "🕓 Day 2, 13:00"
+  },
+  "12": {
+    "photo": "AgADAgADGaoxGz-MeEmwaokZ8HegTIhVXw8ABAktbLuZhbNjvZsDAAEC",
+    "caption": "🕓 Day 2, 14:00"
+  },
+  "13": {
+    "photo": "AgADAgADqqoxG8V5gUnsDttrLjiU64BPOQ8ABLjrYFwYafvYXm4EAAEC",
+    "caption": "🕓 Day 2, 15:00"
+  },
+  "14": {
+    "photo": "AgADAgADLaoxG5ynkUl5RAzI3gyOiThSXw8ABKP77LtTIVnqXakDAAEC",
+    "caption": "🕓 Day 2, 16:00"
+  },
+  "15": {
+    "photo": "AgADAgADz6oxG5ynmUmxlYefNDmGOqZtUw8ABOYOezrbvFinmBwCAAEC",
+    "caption": "🕓 Day 2, 17:00"
+  },
+  "16": {
+    "photo": "AgADAgAD6qoxGz1noEnrD2d4QO9jYl1EOQ8ABHFCsLV1GjGoYYYEAAEC",
+    "caption": "🕓 Day 2, 18:00"
+  }
+}


### PR DESCRIPTION
### Summary

I've taken talk descriptions posted in `Saint P Ruby News` telegram channel and incorporated them into our bot. I'm sorry for making `/schedule` response a bit heavier but where else to put those links to if not there?

### Changes

- Implemented `talk` command
- Added `data/talk_descriptions.json` file containing ids of talk description photos and captions for them
- Added `/talk_n` links for eack talk to `data/schedule.txt`
- Moved `"I can't understand you"` response to a separate method (`bad_command`)

### Previews

<img src="https://user-images.githubusercontent.com/5035283/57339986-95fef000-713c-11e9-9da9-e15916a18002.png" width="320"/>&nbsp;<img src="https://user-images.githubusercontent.com/5035283/57339987-96978680-713c-11e9-90ca-23d2181c8b75.png" width="320"/>




