### PR TITLE
Unify message/callback handling in commands (& fix `Jobs` command)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby '2.6.3'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'rake'
+
 # debug
 gem 'pry'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (2.0.7)
+    rake (12.3.2)
     redis (4.1.0)
     rom (5.0.2)
       rom-changeset (~> 5.0, >= 5.0.1)
@@ -126,6 +127,7 @@ DEPENDENCIES
   oj
   pry
   rack
+  rake
   redis
   rom
   rom-yaml

--- a/app/commands/back.rb
+++ b/app/commands/back.rb
@@ -1,6 +1,8 @@
 module Commands
   class Back < Start
-    def call(message)
+    private
+
+    def handle_call(message)
       send_message(
         chat_id: message.chat.id,
         text: 'Choose from the commands below:',

--- a/app/commands/base.rb
+++ b/app/commands/base.rb
@@ -10,6 +10,26 @@ module Commands
       @api = api
     end
 
+    def call(message)
+      case message
+      when Telegram::Bot::Types::Message
+        handle_call(message)
+      when Telegram::Bot::Types::CallbackQuery
+        args = JSON.parse(message.data)['args']
+        handle_callback(message, args)
+      end
+    end
+
+    private
+
     def_delegators :api, :send_message, :edit_message_text
+
+    def handle_call(message)
+      raise NotImplementedError, "you have to implement #{self.class.name}#handle_call"
+    end
+
+    def handle_callback(callback, args)
+      raise NotImplementedError, "you have to implement #{self.class.name}#handle_callback"
+    end
   end
 end

--- a/app/commands/beers.rb
+++ b/app/commands/beers.rb
@@ -1,6 +1,8 @@
 module Commands
   class Beers < Base
-    def call(message)
+    private
+
+    def handle_call(message)
     end
   end
 end

--- a/app/commands/jobs.rb
+++ b/app/commands/jobs.rb
@@ -2,15 +2,39 @@ module Commands
   class Jobs < Base
     include Import[repo: 'repositories.job_repo']
 
-    def more(id)
-      job = repo.by_id(id)
+    # TODO: send in portions since sending messages is rate limited with 30 calls/sec
+    def handle_call(message)
+      repo.all.each do |job|
+        text =  <<~MARKDOWN
+          *#{job.title}*
+          Company: #{job.company}
+          Location: #{job.location}
+          #{job.short_description}
+        MARKDOWN
 
-      text = ["*#{job['title']}*"]
-      text << "Company: #{job['company']}"
-      text << "Location: #{job['location']}"
-      text << job['announce']
-      text << job['full_description']
-      text.join("\n")
+        send_message(
+          chat_id: message.chat.id,
+          text: text,
+          parse_mode: :markdown,
+          reply_markup: Telegram::Bot::Types::InlineKeyboardMarkup.new(
+            inline_keyboard: [Telegram::Bot::Types::InlineKeyboardButton.new(
+              text: 'Show more',
+              callback_data: { command: 'jobs', args: { job_id: job.id } }.to_json
+            )]
+          )
+        )
+      end
+    end
+
+    def handle_callback(callback, args)
+      job = repo.by_id(args.fetch('job_id'))
+
+      text = <<~MARKDOWN
+        *#{job.title}*
+        Company: #{job.company}
+        Location: #{job.location}
+        #{job.full_description}
+      MARKDOWN
 
       edit_message_text(
         message_id: callback.message.message_id,
@@ -18,23 +42,6 @@ module Commands
         text: text,
         parse_mode: :markdown
       )
-    end
-
-    def call(message)
-      repo.all.each do |job|
-        text = ["*#{job[:title]}*"]
-        text << "Company: #{job[:company]}"
-        text << "Location: #{job[:location]}"
-        text << job[:short_description]
-        text = text.join("\n")
-        more_button = Telegram::Bot::Types::InlineKeyboardMarkup.new(
-          inline_keyboard: [Telegram::Bot::Types::InlineKeyboardButton.new(
-            text: 'Show more',
-            callback_data: { command: 'more', job_id: job.id }.to_json
-          )]
-        )
-        send_message(chat_id: message.chat.id, text: text, parse_mode: :markdown, reply_markup: more_button)
-      end
     end
   end
 end

--- a/app/commands/places.rb
+++ b/app/commands/places.rb
@@ -1,6 +1,8 @@
 module Commands
   class Places < Base
-    def call(message)
+    private
+
+    def handle_call(message)
     end
   end
 end

--- a/app/commands/schedule.rb
+++ b/app/commands/schedule.rb
@@ -9,22 +9,12 @@ module Commands
       ]]
     )
 
-    # 🕓 18:00 🎤 Hiroshi Shibata
-    # 🚩 *The Future of library dependency management of Ruby*
-
-    def call(message)
-      case message
-      when Telegram::Bot::Types::Message
-        handle_message(message)
-      when Telegram::Bot::Types::CallbackQuery
-        args = JSON.parse(message.data)['args']
-        handle_callback(message, args)
-      end
-    end
-
     private
 
-    def handle_message(message)
+    # 🕓 18:00 🎤 Hiroshi Shibata
+    # 🚩 *The Future of library dependency management of Ruby*
+    #
+    def handle_call(message)
       send_message(
         chat_id: message.chat.id,
         text: 'Choose a day:',
@@ -32,19 +22,17 @@ module Commands
       )
     end
 
-    def handle_callback(message, args)
+    def handle_callback(callback, args)
       date = Date.new(2019, 06, args.fetch('confday'))
       talks = repo.by_date(date)
 
       edit_message_text(
-        message_id: message.message.message_id,
-        chat_id: message.message.chat.id,
+        message_id: callback.message.message_id,
+        chat_id: callback.message.chat.id,
         text: talks_message(date, talks),
         parse_mode: :markdown
       )
     end
-
-
 
     def talks_message(confday, talks)
       <<~MARKDOWN

--- a/app/commands/speakers.rb
+++ b/app/commands/speakers.rb
@@ -2,7 +2,9 @@ module Commands
   class Speakers < Base
     SPEAKERS = File.read('./data/speakers.txt')
 
-    def call(message)
+    private
+
+    def handle_call(message)
       send_message(
         chat_id: message.chat.id,
         text: SPEAKERS,

--- a/app/commands/start.rb
+++ b/app/commands/start.rb
@@ -23,7 +23,9 @@ module Commands
       *What can I do for you?*
     """.freeze
 
-    def call(message)
+    private
+
+    def handle_call(message)
       send_message(
         chat_id: message.chat.id,
         text: WELCOME_TEXT,

--- a/app/commands/vote.rb
+++ b/app/commands/vote.rb
@@ -1,6 +1,8 @@
 module Commands
   class Vote < Base
-    def call(message)
+    private
+
+    def handle_call(message)
       vote_button = Telegram::Bot::Types::InlineKeyboardMarkup.new(
         inline_keyboard: [Telegram::Bot::Types::InlineKeyboardButton.new(text: 'Like', callback_data: { command: 'like' }.to_json)]
       )

--- a/app/dispatcher.rb
+++ b/app/dispatcher.rb
@@ -50,7 +50,8 @@ class Dispatcher
       bot.api.answer_callback_query(callback_query_id: callback.id)
     when 'schedule'
       @commands['📆 Schedule'].call(callback)
-    when 'more'
+    when 'jobs'
+      @commands['💵 Jobs'].call(callback)
     end
   end
 end

--- a/lib/repositories/job_repo.rb
+++ b/lib/repositories/job_repo.rb
@@ -3,7 +3,7 @@ module Repositories
     include ArgsImport['rom']
 
     def by_id(id)
-      jobs.by_pk(id)
+      jobs.restrict(id: id).first
     end
 
     def all

--- a/spec/commands/start_spec.rb
+++ b/spec/commands/start_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Commands::Start do
   describe '#call' do
     let(:api) { double('api', send_message: nil) }
-    let(:chat) { double('chat', id: 1) }
-    let(:message) { double('message', chat: chat) }
+    let(:chat) { Telegram::Bot::Types::Chat.new(id: 1) }
+    let(:message) {Telegram::Bot::Types::Message.new(chat: chat) }
 
     subject { described_class.new(api).call(message) }
 


### PR DESCRIPTION
Hi!

I've refactored Commands::Base class a bit to unify handling of commands/callbacks. Each command now has to implement `#handle_call(message)` and/or `#handle_callback(callback, args)` methods. 

Additional changes:

- fixed `Job` command
- added `gem 'rake'` to a Gemfile to be able to run server outside docker (I'm always forgetting to rebuild the container after code changes which leads to a confusion and I believe others could also do so)