### PR TITLE
Introduce keyboard dsl to make code in commands more readable

### DIFF
--- a/app/commands.rb
+++ b/app/commands.rb
@@ -1,3 +1,4 @@
+require_relative 'commands/keyboard_helpers'
 require_relative 'commands/base'
 Dir['./app/commands/*.rb'].each { |f| require f.delete_prefix('app/') }
 

--- a/app/commands/base.rb
+++ b/app/commands/base.rb
@@ -3,6 +3,7 @@ require 'forwardable'
 module Commands
   class Base
     extend Forwardable
+    include KeyboardHelpers
 
     attr_reader :api
 

--- a/app/commands/jobs.rb
+++ b/app/commands/jobs.rb
@@ -16,11 +16,8 @@ module Commands
           chat_id: message.chat.id,
           text: text,
           parse_mode: :markdown,
-          reply_markup: Telegram::Bot::Types::InlineKeyboardMarkup.new(
-            inline_keyboard: [Telegram::Bot::Types::InlineKeyboardButton.new(
-              text: 'Show more',
-              callback_data: { command: 'jobs', args: { job_id: job.id } }.to_json
-            )]
+          reply_markup: inline_keyboard(
+            button('Show more', 'jobs', job_id: job.id)
           )
         )
       end

--- a/app/commands/keyboard_helpers.rb
+++ b/app/commands/keyboard_helpers.rb
@@ -1,0 +1,97 @@
+module Commands
+  # ```
+  # inline_keyboard(button('btn1', 'command', user_id: 1))
+  # ```
+  #
+  # becomes
+  #
+  # ```
+  # Telegram::Bot::Types::InlineKeyboardMarkup.new(inline_keyboard: [
+  #   Telegram::Bot::Types::InlineKeyboardButton.new(
+  #     text: 'btn1',
+  #     callback_data: { command: 'command', args: { user_id: 1 } }.to_json
+  #   )
+  # ])
+  # ```
+  #
+  # ```
+  # reply_keyboard(button('btn1'))
+  # ```
+  #
+  # becomes
+  #
+  # ```
+  # Telegram::Bot::Types::ReplyKeyboardMarkup.new(keyboard: [
+  #   Telegram::Bot::Types::KeyboardButton.new(text: 'btn1')
+  # ])
+  # ```
+  #
+  module KeyboardHelpers
+    Button = Struct.new(:text, :command, :args)
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    private
+
+    def inline_keyboard(*args)
+      self.class.inline_keyboard(*args)
+    end
+
+    def reply_keyboard(*args)
+      self.class.reply_keyboard(*args)
+    end
+
+    def button(*args)
+      self.class.button(*args)
+    end
+
+    module ClassMethods
+      def inline_keyboard(*buttons)
+        Telegram::Bot::Types::InlineKeyboardMarkup.new(
+          inline_keyboard: buttons_to_markup(buttons, :inline)
+        )
+      end
+
+      def reply_keyboard(*buttons)
+        Telegram::Bot::Types::ReplyKeyboardMarkup.new(
+          keyboard: buttons_to_markup(buttons, :reply)
+        )
+      end
+
+      def button(text, command='', args={})
+        Button.new(text, command, args)
+      end
+
+      private
+
+      def buttons_to_markup(buttons, keyboard_type)
+        if buttons.all? { |elem| elem.is_a?(Array) }
+          buttons.map { |btn_block| buttons_to_markup(btn_block, keyboard_type) }
+        elsif buttons.all? { |elem| elem.is_a?(Button) }
+          buttons.map do |button|
+            case keyboard_type
+            when :inline then inline_button_markup(button)
+            when :reply then reply_button_markup(button)
+            end
+          end
+        end
+      end
+
+      def inline_button_markup(button)
+        data = { command: button.command, args: button.args }.to_json
+        raise ArgumentError, 'callback_data is too big' if data.bytesize > 64
+
+        Telegram::Bot::Types::InlineKeyboardButton.new(
+          text: button.text,
+          callback_data: data
+        )
+      end
+
+      def reply_button_markup(button)
+        Telegram::Bot::Types::KeyboardButton.new(text: button.text)
+      end
+    end
+  end
+end

--- a/app/commands/schedule.rb
+++ b/app/commands/schedule.rb
@@ -2,17 +2,17 @@ module Commands
   class Schedule < Base
     include Import[repo: 'repositories.talk_repo']
 
-    CONFDAY_SELECTION_KEYBOARD = Telegram::Bot::Types::InlineKeyboardMarkup.new(
-      inline_keyboard: [[
-        Telegram::Bot::Types::InlineKeyboardButton.new(text: 'June 1, Sat', callback_data: { command: 'schedule', args: { confday: 1 } }.to_json),
-        Telegram::Bot::Types::InlineKeyboardButton.new(text: 'June 2, Sun', callback_data: { command: 'schedule', args: { confday: 2 } }.to_json)
-      ]]
+    CONFDAY_SELECTION_KEYBOARD = inline_keyboard(
+      [
+        button('June 1, Sat', 'schedule', confday: 1),
+        button('June 2, Sun', 'schedule', confday: 2)
+      ]
     )
 
     private
 
-    # 🕓 18:00 🎤 Hiroshi Shibata
-    # 🚩 *The Future of library dependency management of Ruby*
+    # Choose a day:
+    # [ June 1, Sat ] [ June 2, Sun ]
     #
     def handle_call(message)
       send_message(
@@ -22,6 +22,11 @@ module Commands
       )
     end
 
+    # 🕓 18:00 🎤 Hiroshi Shibata
+    # 🚩 *The Future of library dependency management of Ruby*
+    #
+    # ...
+    #
     def handle_callback(callback, args)
       date = Date.new(2019, 06, args.fetch('confday'))
       talks = repo.by_date(date)

--- a/app/commands/start.rb
+++ b/app/commands/start.rb
@@ -1,20 +1,9 @@
 module Commands
   class Start < Base
-    MENU_KEYBOARD = Telegram::Bot::Types::ReplyKeyboardMarkup.new(keyboard:
-      [
-        [
-          Telegram::Bot::Types::KeyboardButton.new(text: '📆 Schedule'),
-          Telegram::Bot::Types::KeyboardButton.new(text: '❤️ Vote')
-        ],
-        [
-          Telegram::Bot::Types::KeyboardButton.new(text: '🎤 Speakers'),
-          Telegram::Bot::Types::KeyboardButton.new(text: '💵 Jobs')
-        ],
-        [
-          Telegram::Bot::Types::KeyboardButton.new(text: '🍻 Beer counter'),
-          Telegram::Bot::Types::KeyboardButton.new(text: '🏛 Places')
-        ],
-      ]
+    MENU_KEYBOARD = reply_keyboard(
+      [ button('📆 Schedule'), button('❤️ Vote') ],
+      [ button('🎤 Speakers'), button('💵 Jobs') ],
+      [ button('🍻 Beer counter'), button('🏛 Places') ]
     )
 
     WELCOME_TEXT = """

--- a/app/commands/vote.rb
+++ b/app/commands/vote.rb
@@ -3,10 +3,11 @@ module Commands
     private
 
     def handle_call(message)
-      vote_button = Telegram::Bot::Types::InlineKeyboardMarkup.new(
-        inline_keyboard: [Telegram::Bot::Types::InlineKeyboardButton.new(text: 'Like', callback_data: { command: 'like' }.to_json)]
+      send_message(
+        chat_id: message.chat.id,
+        text: 'Like this talk',
+        reply_markup: inline_keyboard(button('Like', 'like'))
       )
-      send_message(chat_id: message.chat.id, text: 'Like this talk', reply_markup: vote_button)
     end
   end
 end

--- a/spec/commands/keyboard_helpers_spec.rb
+++ b/spec/commands/keyboard_helpers_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe Commands::KeyboardHelpers do
+  let(:dummy_class) do
+    Class.new do
+      include Commands::KeyboardHelpers
+
+      def inline_keyboard(*args); super; end
+      def reply_keyboard(*args); super; end
+      def button(*args); super; end
+    end
+  end
+
+  let(:dummy) { dummy_class.new }
+
+  describe '#inline_keyboard' do
+    subject(:keyboard) do
+      dummy.inline_keyboard(
+        dummy.button('btn1', 'command', user_id: 1),
+        dummy.button('btn2', 'command', user_id: 2)
+      )
+    end
+
+    it 'produces correct inline keyboard markup' do
+      expect(keyboard.to_compact_hash).to eq (
+        Telegram::Bot::Types::InlineKeyboardMarkup.new(inline_keyboard: [
+          Telegram::Bot::Types::InlineKeyboardButton.new(
+            text: 'btn1',
+            callback_data: { command: 'command', args: { user_id: 1 } }.to_json
+          ),
+          Telegram::Bot::Types::InlineKeyboardButton.new(
+            text: 'btn2',
+            callback_data: { command: 'command', args: { user_id: 2 } }.to_json
+          )
+        ])
+      ).to_compact_hash
+    end
+
+    context 'when callback_data is not longer 64 bytes' do
+      subject(:keyboard) do
+        # callback_data length = 64
+        dummy.inline_keyboard(dummy.button('text', 'command', user_id: '1'*21))
+      end
+
+      it { expect { keyboard }.not_to raise_error }
+    end
+
+    context 'when callback_data is longer that 64 bytes' do
+      subject(:keyboard) do
+        # callback_data length = 65
+        dummy.inline_keyboard(dummy.button('text', 'command', user_id: '1'*22))
+      end
+
+      it { expect { keyboard }.to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '#reply_keyboard' do
+    subject(:keyboard) do
+      dummy
+        .reply_keyboard(dummy.button('btn1'), dummy.button('btn2'))
+        .to_compact_hash
+    end
+
+    it 'produces correct reply keyboard markup' do
+      is_expected.to eq (
+        Telegram::Bot::Types::ReplyKeyboardMarkup.new(keyboard: [
+          Telegram::Bot::Types::KeyboardButton.new(text: 'btn1'),
+          Telegram::Bot::Types::KeyboardButton.new(text: 'btn2')
+        ])
+      ).to_compact_hash
+    end
+  end
+end


### PR DESCRIPTION
As a lazy person not willing to read/write all this `Telegram::Bot::Types::InlineKeyboardMarkup.new(inline_keyboard: [...])` stuff all the time I've implemented a dsl for keyboards. It **is not full** (does not support some features of keyboards that we didn't used yet, like buttons with external urls instead of callbacks) but can be extended when we'll need so

#### The DSL

Everything is impleented in `Commands::KeyboardHelpers` module which is included into `Commands::Base`.

```ruby
inline_keyboard(button('btn1', 'command', user_id: 1))

# becomes

Telegram::Bot::Types::InlineKeyboardMarkup.new(inline_keyboard: [
  Telegram::Bot::Types::InlineKeyboardButton.new(
    text: 'btn1',
    callback_data: { command: 'command', args: { user_id: 1 } }.to_json
  )
])
```

```ruby
reply_keyboard(button('btn1'))

# becomes

Telegram::Bot::Types::ReplyKeyboardMarkup.new(keyboard: [
  Telegram::Bot::Types::KeyboardButton.new(text: 'btn1')
])
```