### PR TITLE
Introduce fallback mechanism for commands & cleanup `Dispatcher`

### DIFF
--- a/app/commands.rb
+++ b/app/commands.rb
@@ -3,4 +3,6 @@ require_relative 'commands/base'
 Dir['./app/commands/*.rb'].each { |f| require f.delete_prefix('app/') }
 
 module Commands
+  Error = Class.new(StandardError)
+  FallbackError = Class.new(Error)
 end

--- a/app/commands/talk.rb
+++ b/app/commands/talk.rb
@@ -10,10 +10,8 @@ module Commands
     # I'm going to show the features of Bundler and RubyGems and the integration plan of RubyGems and Bundler. Also I will show the issues of the current state. You can resolve them after my talk.
     #
     def handle_call(message)
-      id = message.text[%r{(?<=^/talk_)\d+$}]&.to_i
-      return nil unless id
-
-      talk = repo.by_id(id)
+      id = message.text[%r{(?<=^/talk_)\d+$}]&.to_i || raise(FallbackError)
+      talk = repo.by_id(id) || raise(FallbackError)
 
       send_message(
         chat_id: message.chat.id,

--- a/app/commands/unknown.rb
+++ b/app/commands/unknown.rb
@@ -1,0 +1,22 @@
+module Commands
+  class Unknown < Base
+    MESSAGE_TEXT = "Didn't get it".freeze
+    CALLBACK_TEXT = "I can't understand you".freeze
+
+    private
+
+    def handle_call(message)
+      api.send_message(
+        chat_id: message.chat.id,
+        text: MESSAGE_TEXT
+      )
+    end
+
+    def handle_callback(callback, args)
+      api.answer_callback_query(
+        callback_query_id: callback.id,
+        text: CALLBACK_TEXT
+      )
+    end
+  end
+end

--- a/app/commands/vote.rb
+++ b/app/commands/vote.rb
@@ -6,8 +6,13 @@ module Commands
       send_message(
         chat_id: message.chat.id,
         text: 'Like this talk',
-        reply_markup: inline_keyboard(button('Like', 'like'))
+        reply_markup: inline_keyboard(button('Like', 'vote'))
       )
+    end
+
+    def handle_callback(callback, args)
+      # redis.publish('liker_bot', message.from.username)
+      api.answer_callback_query(callback_query_id: callback.id)
     end
   end
 end

--- a/spec/unit/app/commands/unknown_spec.rb
+++ b/spec/unit/app/commands/unknown_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Commands::Unknown do
+  let(:api) { double('api', send_message: nil) }
+  let(:command) { described_class.new(api) }
+
+  let(:chat) { Telegram::Bot::Types::Chat.new(id: 123) }
+  let(:message) { Telegram::Bot::Types::Message.new(chat: chat) }
+
+  describe 'on message' do
+    it 'responds with unknown message text' do
+      expect(api).to receive(:send_message).with(
+        chat_id: 123,
+        text: described_class::MESSAGE_TEXT
+      )
+
+      command.call(message)
+    end
+  end
+
+  describe 'on callback' do
+    let(:callback) do
+      Telegram::Bot::Types::CallbackQuery.new(id: "456", message: message, data: "{}")
+    end
+
+    it 'responds with unknown callback text' do
+      expect(api).to receive(:answer_callback_query).with(
+        callback_query_id: "456",
+        text: described_class::CALLBACK_TEXT
+      )
+
+      command.call(callback)
+    end
+  end
+end

--- a/spec/unit/app/dispatcher_spec.rb
+++ b/spec/unit/app/dispatcher_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe Dispatcher do
+  subject(:dispatcher) { described_class.new(bot) }
+
+  let(:bot) { Telegram::Bot::Client.new('token') }
+  let(:message) { Telegram::Bot::Types::Message.new(text: command_name) }
+
+  let(:command) { instance_double(command_class) }
+  let(:fallback_command) { instance_double(Commands::Unknown) }
+
+  before do
+    allow(command_class).to receive(:new) { command } if defined?(command_class)
+    allow(Commands::Unknown).to receive(:new) { fallback_command }
+  end
+
+  describe 'on message' do
+    context 'if command is recognized' do
+      let(:command_class) { Commands::Schedule }
+      let(:command_name) { '📆 Schedule' }
+
+      it 'executes corresponding command' do
+        expect(command).to receive(:call).with(message)
+        dispatcher.call(message)
+      end
+    end
+
+    context 'if command has trailing digits' do
+      let(:command_class) { Commands::Talk }
+      let(:command_name) { '/talk_123' }
+
+      it 'strips trailing digits when recognizing commands' do
+        expect(command).to receive(:call).with(message)
+        dispatcher.call(message)
+      end
+    end
+
+    context 'if command is not recognized' do
+      let(:command_name) { 'hsbdflgkjs' }
+
+      it 'executes fallback command' do
+        expect(fallback_command).to receive(:call).with(message)
+        dispatcher.call(message)
+      end
+    end
+
+    context 'if recognized command raises FallbackError' do
+      let(:command_class) { Commands::Talk }
+      let(:command_name) { '\talk_123' }
+
+      it 'executes fallback command' do
+        allow(command).to receive(:call).and_raise(Commands::FallbackError)
+        expect(fallback_command).to receive(:call).with(message)
+
+        dispatcher.call(message)
+      end
+    end
+  end
+
+  describe 'on callback' do
+    let(:data) { { command: callback_name, args: {} }.to_json }
+    let(:callback) { Telegram::Bot::Types::CallbackQuery.new(data: data) }
+
+    context 'if callback is recognized' do
+      let(:command_class) { Commands::Schedule }
+      let(:callback_name) { 'schedule' }
+
+      it 'executes corresponding command' do
+        expect(command).to receive(:call).with(callback)
+        dispatcher.call(callback)
+      end
+    end
+
+    context 'if callback is not recognized' do
+      let(:callback_name) { 'ksjdflgsj' }
+
+      it 'executes fallback command' do
+        expect(fallback_command).to receive(:call).with(callback)
+        dispatcher.call(callback)
+      end
+    end
+
+    context 'if callback data is not parseable' do
+      let(:callback_name) { 'jobs' }
+      let(:data) { "not a JSON" }
+
+      it 'executes fallback command' do
+        expect(fallback_command).to receive(:call).with(callback)
+        dispatcher.call(callback)
+      end
+    end
+
+    context 'if recognized callback raises FallbackError' do
+      let(:command_class) { Commands::Vote }
+      let(:callback_name) { '❤️ Vote' }
+
+      it 'executes fallback command' do
+        allow(command).to receive(:call).and_raise(Commands::FallbackError)
+        expect(fallback_command).to receive(:call).with(callback)
+
+        dispatcher.call(callback)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In my prev PR I've encountered a situation when command can fail to execute because of incorrect arguments (\talk_1234567 -- there is no talk with such an ID). In a situation like that a bot should probably reply with something like `"I don't understand"`, but `Dispatcher` (which had previously been responsible for sending such a message) has already chosen a command to execute, so I needed some kind of a fallback mechanism.

Here I introduce such a mechanism: `Dispatcher` now has a fallback command (I called it `Commands::Unknown`, the name is arguable), and a command willing to initiate fallback should raise a `FallbackError` exception.

Additional benefit is that I've moved everything related to bot API interactions out from `Dispatcher`, so it is now focused on a single responsibility: select and execute a command.